### PR TITLE
MULE-19884: Adjust the parsing state to handle 100-continue response in HttpClientFilter

### DIFF
--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpClientFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpClientFilter.java
@@ -438,6 +438,24 @@ public class HttpClientFilter extends HttpCodecFilter {
                     parsingState.start = -1;
                     parsingState.checkpoint = -1;
                     onInitialLineParsed(httpResponse, ctx);
+
+                    if (httpResponse.getStatus() == 100 && parsingState.offset + 1 < input.length) {
+                        // reset the parsing state in preparation to parse
+                        // another initial line which represents the final
+                        // response from the server after it has sent a
+                        // 100-Continue.
+                        parsingState.start = parsingState.offset;
+
+                        if (parsingState.start < end && input[parsingState.start] == Constants.LF
+                                && input[parsingState.start+1] == Constants.LF)
+                        {
+                            parsingState.offset += 2;
+                            parsingState.subState = 0;
+                            continue;
+                        }
+                        return true;
+                    }
+
                     return true;
                 }
 

--- a/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
+++ b/modules/http/src/main/java/org/glassfish/grizzly/http/HttpCodecFilter.java
@@ -815,7 +815,8 @@ public abstract class HttpCodecFilter extends HttpBaseFilter
                 }
                 if (is100Continue(httpPacket)) {
                     if (parsingState.offset < end) {
-                        while (inputBuffer.get(parsingState.offset) == '\r' || inputBuffer.get(parsingState.offset) == '\n') {
+                        while (parsingState.offset < inputBuffer.limit() && (inputBuffer.get(parsingState.offset) == '\r'
+                                || inputBuffer.get(parsingState.offset) == '\n')) {
                             parsingState.offset += 1;
                         }
 

--- a/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
+++ b/modules/http/src/test/java/org/glassfish/grizzly/http/HttpResponseParseTest.java
@@ -105,7 +105,6 @@ public class HttpResponseParseTest extends TestCase {
         headers.put("Content-length", new Pair<String, String>("2345", "2345"));
         doHttpResponseTest("HTTP/1.0", 200, "DONE", headers, "\r\n");
     }
-    
 
     public void testHeadersN() throws Exception {
         Map<String, Pair<String, String>> headers =
@@ -124,7 +123,7 @@ public class HttpResponseParseTest extends TestCase {
     }
 
     public void testDecoder100continueWithAHeaderThen200() {
-        HttpPacket packet = doTestDecoder("HTTP/1.1 100 Continue\r\nConnection: keep-alive\r\n\r\nHTTP/1.1 200 OK\r\n\r\n", 4096);
+        HttpPacket packet = doTestDecoder("HTTP/1.1 100 Continue\r\nConnection: keep-alive\n\nHTTP/1.1 200 OK\n\n", 4096);
         assertTrue(packet.getHttpHeader() instanceof HttpResponsePacket);
         HttpResponsePacket response = (HttpResponsePacket) packet.getHttpHeader();
         assertEquals(200, response.getStatus());
@@ -139,11 +138,20 @@ public class HttpResponseParseTest extends TestCase {
         assertEquals(200, ((HttpResponsePacket) lastPacket.getHttpHeader()).getStatus());
     }
 
+    public void testDecoder100continueAndResponseUsingSameConnectionWithCrLf() throws IOException {
+        HttpClientFilter filter = new HttpClientFilter(4096);
+        FilterChainContext ctx = FilterChainContext.create(new StandaloneConnection());
+
+        handleRead(filter, ctx, "HTTP/1.1 100 Continue\r\n\r\n");
+        HttpPacket lastPacket = (HttpPacket) handleRead(filter, ctx, "HTTP/1.1 200 OK\r\n\r\n");
+        assertEquals(200, ((HttpResponsePacket) lastPacket.getHttpHeader()).getStatus());
+    }
+
     public void testDecoder100continueAndResponseUsingSameConnectionWithHeader() throws IOException {
         HttpClientFilter filter = new HttpClientFilter(4096);
         FilterChainContext ctx = FilterChainContext.create(new StandaloneConnection());
 
-        handleRead(filter, ctx, "HTTP/1.1 100 Continue\nConnection: keep-alive\n\n");
+        handleRead(filter, ctx, "HTTP/1.1 100 Continue\r\nConnection: keep-alive\n\n");
         HttpPacket lastPacket = (HttpPacket) handleRead(filter, ctx, "HTTP/1.1 200 OK\n\n");
         assertEquals(200, ((HttpResponsePacket) lastPacket.getHttpHeader()).getStatus());
     }


### PR DESCRIPTION
…in HttpClientFilter

* resetting the parsing state to parse the initial line of 100-continue response with correct start/offset value